### PR TITLE
Fixed socket not assigning a name to a new player

### DIFF
--- a/Front-End/app/src/app/components/profile/profile.component.ts
+++ b/Front-End/app/src/app/components/profile/profile.component.ts
@@ -59,9 +59,13 @@ export class ProfileComponent implements OnInit {
         //If the backend is unable to find the profile from the email then
         //it throws an error, when it does it creates the player profile
         this.currentPlayer.playerName = this.tempName;
+        
         this.profApi.addPlayerProfile(this.currentPlayer).subscribe(
           (response) => {
             this.currentPlayer.id = response.id;
+            if (response.playerName) {
+              this.socketService.SetUsername(this.tempName!)
+            }
           }
         );
       }


### PR DESCRIPTION
Realized that a new player wouldnt have their socket name set. This fixes it